### PR TITLE
Added Ford Mustang GT3 and GT2s to the Setup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,7 @@ const mechanicalSetup = [
     displayItem(s?.advancedSetup.mechanicalBalance.aRBFront),
     displayItem(s?.advancedSetup.mechanicalBalance.aRBRear)
   ]],
-  ['Diff preload [Nm]', (s) => [displayItem(s && s.advancedSetup.drivetrain.preload * 10 + 20)]],
+  ['Diff preload [Nm]', (s, c) => [displayItem(s && s.advancedSetup.drivetrain.preload * 10 + parseInt((c.minPreload ? c.minPreload : 20)))]],
   ['Brake power [%]', (s) => [displayItem(s && s.advancedSetup.mechanicalBalance.brakeTorque + 80)]],
   ['Brake bias [%]', (s, c) => [displayItem(s && s.advancedSetup.mechanicalBalance.brakeBias / 5 + c.brakeBiasMin)]],
   ['Steering ratio', (s, c) => [displayItem(s && s.basicSetup.alignment.steerRatio + c.steeringRatioMin)]],
@@ -57,8 +57,8 @@ const aeroSetup = [
     displayItem(s && s.advancedSetup.aeroBalance.rideHeight[2] + c.rideHeightMinRear)
   ]],
   ['Brake ducts', (s) => s?.advancedSetup.aeroBalance.brakeDuct.map((v) => displayItem(v))],
-  ['Splitter', (s) => [displayItem(s && s.advancedSetup.aeroBalance.splitter + 1)]],
-  ['Wing', (s) => [displayItem(s && s.advancedSetup.aeroBalance.rearWing)]]
+  ['Splitter', (s) => [displayItem(s && s.advancedSetup.aeroBalance.splitter)]],
+  ['Wing', (s, c) => [displayItem(s && s.advancedSetup.aeroBalance.rearWing + (c.minWing ? c.minWing : 0))]],
 ];
 
 const setupGroups = [

--- a/src/CarData.js
+++ b/src/CarData.js
@@ -168,13 +168,12 @@ const data = {
         rideHeightMinFront: 55,
         rideHeightMinRear: 55
     },
-    // Add Ford Mustang GT3
     ford_mustang_gt3: {
         name: 'Ford Mustang GT3',
         tirePressureMin: 20.3,
-        casterFunc: (v) => v * 0.175 + 5.3, // Update
-        toeMins: [-0.4, -0.4],
-        wheelRates: [   // Fill In Vals
+        casterFunc: (v) => v * 0.175 + 5.3,
+        toeMins: [-0.2, -0.1],
+        wheelRates: [
             [105, 120, 135, 150, 165, 180],
             [90, 105, 120, 135, 150, 165]
         ],

--- a/src/CarData.js
+++ b/src/CarData.js
@@ -168,6 +168,21 @@ const data = {
         rideHeightMinFront: 55,
         rideHeightMinRear: 55
     },
+    // Add Ford Mustang GT3
+    ford_mustang_gt3: {
+        name: 'Ford Mustang GT3',
+        tirePressureMin: 20.3,
+        casterFunc: (v) => v * 0.175 + 5.3, // Update
+        toeMins: [-0.4, -0.4],
+        wheelRates: [   // Fill In Vals
+            [105, 120, 135, 150, 165, 180],
+            [90, 105, 120, 135, 150, 165]
+        ],
+        steeringRatioMin: 10,
+        brakeBiasMin: 48.5,
+        rideHeightMinFront: 50,
+        rideHeightMinRear: 50
+    },
     honda_nsx_gt3: {
         name: 'Honda NSX GT3',
         tirePressureMin: 20.3,

--- a/src/CarData.js
+++ b/src/CarData.js
@@ -666,6 +666,102 @@ const data = {
         brakeBiasMin: 56,
         rideHeightMinFront: 125,
         rideHeightMinRear: 125
+    },
+
+    // GT2
+    audi_r8_lms_gt2: {
+        name: "Audi R8 LMS GT2",
+        tirePressureMin: 17,
+        casterFunc: (v) => v * (13.3 - 6.6) / 34 + 6.6,
+        toeMins: [-0.4, -0.4],
+        wheelRates: [
+            [142, 160],
+            [146, 163]
+        ],
+        steeringRatioMin: 12,
+        brakeBiasMin: 50,
+        rideHeightMinFront: 80,
+        rideHeightMinRear: 80,
+        minPreload: 10
+    },
+    ktm_xbow_gt2: {
+        name: "KTM X-Bow GT2",
+        tirePressureMin: 17,
+        casterFunc: (v) => v * 0.215 + 3.2,
+        toeMins: [-0.4, -0.4],
+        wheelRates: [
+            [87, 97, 107, 117, 127],
+            [81, 91, 101, 111, 121, 131]
+        ],
+        steeringRatioMin: 11,
+        brakeBiasMin: 44,
+        rideHeightMinFront: 75,
+        rideHeightMinRear: 200,
+        minPreload: 10,
+        minWing: 1
+    },
+    maserati_mc20_gt2: {
+        name: "Maserati MC20 GT2",
+        tirePressureMin: 17,
+        casterFunc: (v) => v * 0.18 + 8.5,
+        toeMins: [-0.4, -0.4],
+        wheelRates: [
+            [165.18, 179.54, 193.9],
+            [173.913, 189.036, 204.158]
+        ],
+        steeringRatioMin: 11,
+        brakeBiasMin: 55,
+        rideHeightMinFront: 80,
+        rideHeightMinRear: 80,
+        minWing: 1
+    },
+    mercedes_amg_gt2: {
+        name: "Mercedes-AMG GT2",
+        tirePressureMin: 17,
+        casterFunc: (v) => v * 0.18 + 9.2,
+        toeMins: [-0.2, 0.0],
+        wheelRates: [
+            [78, 88, 104],
+            [66, 76, 86]
+        ],
+        steeringRatioMin: 10,
+        brakeBiasMin: 55,
+        rideHeightMinFront: 122,
+        rideHeightMinRear: 140,
+        minPreload: 10,
+        minWing: 1
+    },
+    porsche_935: {
+        name: "Porsche 935",
+        tirePressureMin: 17,
+        casterFunc: (v) => v * 0.1 + 7.3,
+        toeMins: [-0.4, -0.4],
+        wheelRates: [
+            [0, 0.001, 0.002, 0.003],
+            [0, 0.001, 0.002, 0.003]
+        ],
+        steeringRatioMin: 11,
+        brakeBiasMin: 50,
+        rideHeightMinFront: 90,
+        rideHeightMinRear: 160,
+        minPreload: 0.1,
+        minWing: 1
+    },
+    porsche_991_gt2_rs_mr: {
+        name: "Porsche 991 GT2 RS Clubsport MR",
+        tirePressureMin: 17,
+        casterFunc: (v) => v * 0.1 + 7.3,
+        toeMins: [-0.4, -0.4],
+        wheelRates: [
+            [0, 0.001, 0.002, 0.003],
+            [0, 0.001, 0.002, 0.003]
+        ],
+        steeringRatioMin: 11,
+        brakeBiasMin: 50,
+        rideHeightMinFront: 100,
+        rideHeightMinRear: 167,
+        minPreload: 0.1,
+        minWing: 1
     }
 }
 


### PR DESCRIPTION
So I forked over the setup comparer app because it didn't support the Ford Mustang. I added the Car data for the Ford and decided to go further and add the GT2s. 

In the GT2s Kunos got inconsistent with the values such as the rear wing and some of the GT2 cars have a different minimum preload. Some have 10 and the Porsches have 0. As for the rear wing, all GT2 cars except for the Audi have a minimum value of 1. I just added a conditional so the other car data don't need to be modified.

Additionally, I also noticed that the splitter is set to a minimum of 1 on all cars so set to 0, I checked it with both cars that have and don't have adjustable splitters.

Feel free to correct it, and lemme know what's wrong.